### PR TITLE
Баг #83: Неверный тип ключа при голосовании за делегата

### DIFF
--- a/app/components/modules/LoginForm.jsx
+++ b/app/components/modules/LoginForm.jsx
@@ -135,7 +135,8 @@ class LoginForm extends Component {
             translate('authenticate_for_this_transaction') :
             translate('login_to_your_APP_NAME_account');
         const opType = loginBroadcastOperation ? loginBroadcastOperation.get('type') : null
-        const authType = translate(/vote|comment/.test(opType) ? 'posting' : 'active_or_owner')
+        const authType = translate(/^vote|comment/.test(opType) ? 'posting' : 'active_or_owner')
+
         const submitLabel = translate(loginBroadcastOperation ? 'sign' : 'login');
         let error = password.touched && password.error ? password.error : this.props.login_error
         if (error === 'owner_login_blocked') {


### PR DESCRIPTION
Фикс для https://github.com/GolosChain/tolstoy/issues/83

Стащил из steemit.com. Без `^` регулярное выражение захватывает как `vote` так и `witness_vote`, для которого нужен другой тип ключа