### PR TITLE
Sorting tags by parameters. Close #334

### DIFF
--- a/app/components/pages/TagsIndex.scss
+++ b/app/components/pages/TagsIndex.scss
@@ -4,6 +4,12 @@
   }
 
   table tr {
+    th {
+      cursor: pointer;
+      &:hover .TagsIndex__tagToggle {
+        opacity: 1;
+      }
+    }
     td, th {
       text-align: right;
       &:first-child {
@@ -54,6 +60,13 @@
         padding-left: 2rem;
       }
     }
+  }
+}
+
+.TagsIndex__tagToggle {
+  opacity: 0;
+  &.isSelected {
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
Tags on tags/promoted route used to be displayed as a simple table. I made them sortable by  
parameters in both ascending and descending order by adding toggle indicators and making table heads clickable.