### PR TITLE
1211 mobile text editor fixes

### DIFF
--- a/app/components/elements/postEditor/PostFooter/PostFooter.jsx
+++ b/app/components/elements/postEditor/PostFooter/PostFooter.jsx
@@ -11,6 +11,7 @@ import PostOptions from 'app/components/elements/postEditor/PostOptions/PostOpti
 import Button from 'app/components/elements/common/Button';
 import Hint from 'app/components/elements/common/Hint';
 import Icon from 'golos-ui/Icon';
+import InfoIcon from 'app/components/elements/Icon';
 import PreviewButton from 'app/components/elements/postEditor/PreviewButton';
 import { NSFW_TAG } from 'app/utils/tags';
 
@@ -107,6 +108,30 @@ const ClearButton = styled.button`
     cursor: pointer;
 `;
 
+const MobileError = styled.p`
+    display: flex;
+    align-items: center;
+    width: 100%;
+    margin: 0;
+    padding: 12px 16px 0;
+    font-size: 14px;
+    line-height: 1.43;
+    letter-spacing: normal;
+    color: #333;
+
+    ${is('isError')`
+        color: #fc5d16;
+    `};
+
+    @media (min-width: 861px) {
+        display: none;
+    }
+`;
+
+const ErrorIcon = styled(InfoIcon)`
+    margin-right: 18px;
+`;
+
 export default class PostFooter extends PureComponent {
     static propTypes = {
         editMode: PropTypes.bool,
@@ -167,6 +192,18 @@ export default class PostFooter extends PureComponent {
                             />
                         )}
                     </Tags>
+                    {temporaryErrorText && !disabledHint && (
+                        <MobileError isError>
+                            <ErrorIcon name="editor/info" />
+                            {temporaryErrorText}
+                        </MobileError>
+                    )}
+                    {!temporaryErrorText && disabledHint && (
+                        <MobileError isError>
+                            <ErrorIcon name="editor/info" />
+                            {disabledHint}
+                        </MobileError>
+                    )}
                     <PostOptions
                         nsfw={this.props.tags.includes(NSFW_TAG)}
                         payoutType={this.props.payoutType}

--- a/app/components/elements/postEditor/PostTitle/PostTitle.jsx
+++ b/app/components/elements/postEditor/PostTitle/PostTitle.jsx
@@ -78,13 +78,19 @@ export default class PostTitle extends PureComponent {
         }
     }
 
+    componentDidMount() {
+        if (this.props.initialValue && !this.inputRef.current.innerText) {
+            this.inputRef.current.innerText = this.props.initialValue;
+        }
+    }
+
     componentWillUnmount() {
         clearTimeout(this._dotTimeout);
     }
 
-    reset() {
+    reset = () => {
         this.inputRef.current.innerText = '';
-    }
+    };
 
     render() {
         const { placeholder } = this.props;

--- a/app/components/modules/PostForm/PostForm.jsx
+++ b/app/components/modules/PostForm/PostForm.jsx
@@ -356,7 +356,7 @@ export default class PostForm extends React.Component {
                         ) : (
                             <Fragment>
                                 <PostTitle
-                                    innerRef={this.postTitle}
+                                    ref={this.postTitle}
                                     initialValue={title}
                                     placeholder={tt('post_editor.title_placeholder')}
                                     validate={this._validateTitle}

--- a/src/app/containers/post/activePanel/ActivePanel.jsx
+++ b/src/app/containers/post/activePanel/ActivePanel.jsx
@@ -267,7 +267,10 @@ export class ActivePanel extends Component {
                         data-tooltip={shareTooltip}
                         aria-label={shareTooltip}
                     >
-                        <PopoverBackgroundShade show={showSharePopover} />
+                        <PopoverBackgroundShade
+                            show={showSharePopover}
+                            onClick={this.closeSharePopover}
+                        />
                         <Icon
                             width="26"
                             height="26"
@@ -290,7 +293,10 @@ export class ActivePanel extends Component {
                     data-tooltip={dotsTooltip}
                     aria-label={dotsTooltip}
                 >
-                    <PopoverBackgroundShade show={showDotsPopover} />
+                    <PopoverBackgroundShade
+                        show={showDotsPopover}
+                        onClick={this.closeDotsPopover}
+                    />
                     <Icon
                         width="32"
                         height="32"


### PR DESCRIPTION
Поправлено: 
- отображение ошибок
- кнопка очистки
- сохранение тайтла после перезагрузки страницы
- закрытие попапа по нажатию на оверлэй
